### PR TITLE
Py3 Port

### DIFF
--- a/OCCUtils/Common.py
+++ b/OCCUtils/Common.py
@@ -170,7 +170,7 @@ def interpolate_points_to_spline(list_of_points, start_tangent, end_tangent, fil
         if interp.IsDone():
             return interp.Curve()
     except RuntimeError:
-        print 'FAILED TO INTERPOLATE THE SHOWN POINTS'
+        print("Failed to interpolate the shown points")
 
 
 def interpolate_points_vectors_to_spline(list_of_points, list_of_vectors, vector_mask=[], tolerance=TOLERANCE):
@@ -239,7 +239,6 @@ def interpolate_points_to_spline_no_tangency(list_of_points, filter=True, closed
 # --- RANDOMNESS ---
 #===========================================================================
 
-
 def random_vec():
     import random
     x, y, z = [random.uniform(-1, 1) for i in range(3)]
@@ -250,7 +249,7 @@ def random_colored_material_aspect():
     import random
     clrs = [i for i in dir(Graphic3d) if i.startswith('Graphic3d_NOM_')]
     color = random.sample(clrs, 1)[0]
-    print 'color', color
+    print("color", color)
     return Graphic3d.Graphic3d_MaterialAspect(getattr(Graphic3d, color))
 
 
@@ -319,7 +318,7 @@ def point_in_solid(solid, pnt, tolerance=1e-5):
     from OCC.BRepClass3d import BRepClass3d_SolidClassifier
     from OCC.TopAbs import TopAbs_ON, TopAbs_OUT, TopAbs_IN
     _in_solid = BRepClass3d_SolidClassifier(solid, pnt, tolerance)
-    print 'STATE', _in_solid.State()
+    print("State", _in_solid.State())
     if _in_solid.State() == TopAbs_ON:
         return None, 'on'
     if _in_solid.State() == TopAbs_OUT:
@@ -433,7 +432,7 @@ def resample_curve_with_uniform_deflection(curve, deflection=0.5, degreeMin=3, d
     crv = to_adaptor_3d(curve)
     defl = GCPnts_UniformDeflection(crv, deflection)
     with assert_isdone(defl, 'failed to compute UniformDeflection'):
-        print 'number of points:', defl.NbPoints()
+        print("Number of points:", defl.NbPoints())
     sampled_pnts = [defl.Value(i) for i in xrange(1, defl.NbPoints())]
     resampled_curve = GeomAPI_PointsToBSpline(point_list_to_TColgp_Array1OfPnt(sampled_pnts), degreeMin, degreeMax, continuity, tolerance)
     return resampled_curve.Curve().GetObject()

--- a/OCCUtils/Construct.py
+++ b/OCCUtils/Construct.py
@@ -629,10 +629,10 @@ def sew_shapes(shapes, tolerance=0.001):
         else:
             sew.Add(shp)
     sew.Perform()
-    print 'n degenerated shapes', sew.NbDegeneratedShapes()
-    print 'n deleted faces:', sew.NbDeletedFaces()
-    print 'n free edges', sew.NbFreeEdges()
-    print 'n multiple edges:', sew.NbMultipleEdges()
+    print("n degenerated shapes", sew.NbDegeneratedShapes())
+    print("n deleted faces:", sew.NbDeletedFaces())
+    print("n free edges", sew.NbFreeEdges())
+    print("n multiple edges:", sew.NbMultipleEdges())
     result = ShapeToTopology()(sew.SewedShape())
     return result
 
@@ -644,7 +644,7 @@ def boolean_cut(shapeToCutFrom, cuttingShape):
     from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut
     try:
         cut = BRepAlgoAPI_Cut(shapeToCutFrom, cuttingShape)
-        print 'can work?', cut.BuilderCanWork()
+        print("Can work?", cut.BuilderCanWork())
         _error = {0: '- Ok',
                   1: '- The Object is created but Nothing is Done',
                   2: '- Null source shapes is not allowed',
@@ -654,14 +654,14 @@ def boolean_cut(shapeToCutFrom, cuttingShape):
                   6: '- Unknown operation is not allowed',
                   7: '- Can not allocate memory for the Builder',
                   }
-        print 'error status:', _error[cut.ErrorStatus()]
+        print("Error status:", _error[cut.ErrorStatus()])
         cut.RefineEdges()
         cut.FuseEdges()
         shp = cut.Shape()
         cut.Destroy()
         return shp
     except:
-        print 'FAILED TO BOOLEAN CUT'
+        print("Failed to boolean cut")
         return shapeToCutFrom
 
 

--- a/OCCUtils/Iteration.py
+++ b/OCCUtils/Iteration.py
@@ -39,8 +39,8 @@ class EdgePairsFromWire(object):
     def next(self):
         if self.index == 0:
             # first edge, need to set self.previous_edge
-            self.previous_edge = self.we.next()
-            self.current_edge = self.we.next()
+            self.previous_edge = next(self.we)
+            self.current_edge = next(self.we)
             self.first_edge = self.previous_edge   # for the last iteration
             self.index += 1
             return [self.previous_edge, self.current_edge]
@@ -50,7 +50,7 @@ class EdgePairsFromWire(object):
             return [self.current_edge, self.first_edge]
         else:
             self.previous_edge = self.current_edge
-            self.current_edge = self.we.next()
+            self.current_edge = next(self.we)
             self.index += 1
             return [self.previous_edge, self.current_edge]
 
@@ -95,8 +95,8 @@ class LoopWirePairs(object):
         closest = self.closest_point(vert)
         edges_a = self.tp_A.edges_from_vertex(vert)
         edges_b = self.tp_B.edges_from_vertex(closest)
-        a1, a2 = Edge(edges_a.next()), Edge(edges_a.next())
-        b1, b2 = Edge(edges_b.next()), Edge(edges_b.next())
+        a1, a2 = Edge(next(edges_a)), Edge(next(edges_a))
+        b1, b2 = Edge(next(edges_b)), Edge(next(edges_b))
         mpA = a1.mid_point()
         self.index += 1
 

--- a/OCCUtils/edge.py
+++ b/OCCUtils/edge.py
@@ -52,7 +52,7 @@ class IntersectCurve(object):
             face_curve_intersect.Init(other, self.instance.adaptor.Curve(), tolerance)
             pnts = []
             while face_curve_intersect.More():
-                face_curve_intersect.Next()
+                next(face_curve_intersect)
                 pnts.append(face_curve_intersect.Pnt())
             return pnts
 
@@ -560,6 +560,6 @@ if __name__ == '__main__':
     from Topology import Topo
     b = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
     t = Topo(b)
-    ed = t.edges().next()
+    ed = next(t.edges())
     my_e = Edge(ed)
     print(my_e.tolerance)

--- a/OCCUtils/edge.py
+++ b/OCCUtils/edge.py
@@ -375,7 +375,6 @@ class Edge(TopoDS_Edge, KbeObject):
         elif ubound:
             _ubound = ubound
 
-
         # minimally two points or a Standard_ConstructionError is raised
         if n_pts <= 1:
             n_pts = 2
@@ -383,7 +382,7 @@ class Edge(TopoDS_Edge, KbeObject):
         try:
             npts = GCPnts_UniformAbscissa(self.adaptor, n_pts, _lbound, _ubound)
         except:
-            print "Warning : GCPnts_UniformAbscissa failed"
+            print("Warning : GCPnts_UniformAbscissa failed")
         if npts.IsDone():
             tmp = []
             for i in xrange(1, npts.NbPoints()+1):

--- a/OCCUtils/face.py
+++ b/OCCUtils/face.py
@@ -451,7 +451,7 @@ class Face(TopoDS_Face, KbeObject):
         return iso
 
     def Edges(self):
-        return [Edge(i) for i in WireExplorer(self.topo.wires().next()).ordered_edges()]
+        return [Edge(i) for i in WireExplorer(next(self.topo.wires())).ordered_edges()]
 
     def __repr__(self):
         return self.name

--- a/OCCUtils/types_lut.py
+++ b/OCCUtils/types_lut.py
@@ -28,15 +28,14 @@ class ShapeToTopology(object):
     looks up the topology type and returns the corresponding topological entity
     '''
     def __init__(self):
-        self.tds = topods()
-        self.topoTypes = {TopAbs_VERTEX:      self.tds.Vertex,
-                          TopAbs_EDGE:        self.tds.Edge,
-                          TopAbs_FACE:        self.tds.Face,
-                          TopAbs_WIRE:        self.tds.Wire,
-                          TopAbs_SHELL:       self.tds.Shell,
-                          TopAbs_SOLID:       self.tds.Solid,
-                          TopAbs_COMPOUND:    self.tds.Compound,
-                          TopAbs_COMPSOLID:   self.tds.CompSolid,
+        self.topoTypes = {TopAbs_VERTEX:      topods.Vertex,
+                          TopAbs_EDGE:        topods.Edge,
+                          TopAbs_FACE:        topods.Face,
+                          TopAbs_WIRE:        topods.Wire,
+                          TopAbs_SHELL:       topods.Shell,
+                          TopAbs_SOLID:       topods.Solid,
+                          TopAbs_COMPOUND:    topods.Compound,
+                          TopAbs_COMPSOLID:   topods.CompSolid,
                           }
 
     def __call__(self, shape):
@@ -105,7 +104,7 @@ _geom_types_b = [GeomAbs_Line, GeomAbs_Circle, GeomAbs_Ellipse,
 # no need for 2 lists to define an EnumLookup
 
 def fix_formatting(_str):
-    return [i.strip() for i in _str.decode('string_escape').split(',')]
+    return [i.strip() for i in _str.split(',')]
 
 _brep_check_a = fix_formatting("NoError, InvalidPointOnCurve,\
 InvalidPointOnCurveOnSurface, InvalidPointOnSurface,\
@@ -167,8 +166,8 @@ for elem in classes:
 def what_is_face(face):
     ''' Returns all class names for which this class can be downcasted
     '''
-    if not face.ShapeType()==TopAbs_FACE:
-        print '%s is not a TopAbs_FACE. Conversion impossible'
+    if not face.ShapeType() == TopAbs_FACE:
+        print('%s is not a TopAbs_FACE. Conversion impossible')
         return None
     hs = BRep_Tool_Surface(face)
     obj = hs.GetObject()

--- a/test/occutils_test.py
+++ b/test/occutils_test.py
@@ -87,59 +87,59 @@ class TestTopo(unittest.TestCase):
             _tmp.append(0 == f.IsNull())
         for f in _faces:
             _tmp.append(0 == f.IsNull())
-        self.assert_(all(_tmp))
+        self.assertTrue(all(_tmp))
 
     def test_edge_face(self):
-        edg = self.topo.edges().next()
-        face = self.topo.faces().next()
+        edg = next(self.topo.edges())
+        face = next(self.topo.faces())
         faces_from_edge = [i for i in self.topo.faces_from_edge(edg)]
-        self.assert_(len(faces_from_edge) == self.topo.number_of_faces_from_edge(edg))
+        self.assertTrue(len(faces_from_edge) == self.topo.number_of_faces_from_edge(edg))
         edges_from_face = [i for i in self.topo.edges_from_face(face)]
-        self.assert_(len(edges_from_face) == self.topo.number_of_edges_from_face(face))
+        self.assertTrue(len(edges_from_face) == self.topo.number_of_edges_from_face(face))
 
     def test_edge_wire(self):
-        edg = self.topo.edges().next()
-        wire = self.topo.wires().next()
+        edg = next(self.topo.edges())
+        wire = next(self.topo.wires())
         wires_from_edge = [i for i in self.topo.wires_from_edge(edg)]
-        self.assert_(len(wires_from_edge) == self.topo.number_of_wires_from_edge(edg))
+        self.assertTrue(len(wires_from_edge) == self.topo.number_of_wires_from_edge(edg))
         edges_from_wire = [i for i in self.topo.edges_from_wire(wire)]
-        self.assert_(len(edges_from_wire) == self.topo.number_of_edges_from_wire(wire))
+        self.assertTrue(len(edges_from_wire) == self.topo.number_of_edges_from_wire(wire))
 
     def test_vertex_edge(self):
-        vert = self.topo.vertices().next()
-        edge = self.topo.edges().next()
+        vert = next(self.topo.vertices())
+        edge = next(self.topo.edges())
         verts_from_edge = [i for i in self.topo.vertices_from_edge(edge)]
-        self.assert_(len(verts_from_edge) == self.topo.number_of_vertices_from_edge(edge))
+        self.assertTrue(len(verts_from_edge) == self.topo.number_of_vertices_from_edge(edge))
         edges_from_vert = [i for i in self.topo.edges_from_vertex(vert)]
-        self.assert_(len(edges_from_vert) == self.topo.number_of_edges_from_vertex(vert))
+        self.assertTrue(len(edges_from_vert) == self.topo.number_of_edges_from_vertex(vert))
 
     def test_vertex_face(self):
-        vert = self.topo.vertices().next()
-        face = self.topo.faces().next()
+        vert = next(self.topo.vertices())
+        face = next(self.topo.faces())
         faces_from_vertex = [i for i in self.topo.faces_from_vertex(vert)]
-        self.assert_(len(faces_from_vertex) == self.topo.number_of_faces_from_vertex(vert))
+        self.assertTrue(len(faces_from_vertex) == self.topo.number_of_faces_from_vertex(vert))
         verts_from_face = [i for i in self.topo.vertices_from_face(face)]
-        self.assert_(len(verts_from_face) == self.topo.number_of_vertices_from_face(face))
+        self.assertTrue(len(verts_from_face) == self.topo.number_of_vertices_from_face(face))
 
     def test_face_solid(self):
-        face = self.topo.faces().next()
-        solid = self.topo.solids().next()
+        face = next(self.topo.faces())
+        solid = next(self.topo.solids())
         faces_from_solid = [i for i in self.topo.faces_from_solids(solid)]
-        self.assert_(len(faces_from_solid) == self.topo.number_of_faces_from_solids(solid))
+        self.assertTrue(len(faces_from_solid) == self.topo.number_of_faces_from_solids(solid))
         solids_from_face = [i for i in self.topo.solids_from_face(face)]
-        self.assert_(len(solids_from_face) == self.topo.number_of_solids_from_face(face))
+        self.assertTrue(len(solids_from_face) == self.topo.number_of_solids_from_face(face))
 
     def test_wire_face(self):
-        wire = self.topo.wires().next()
-        face = self.topo.faces().next()
+        wire = next(self.topo.wires())
+        face = next(self.topo.faces())
         faces_from_wire = [i for i in self.topo.faces_from_wire(wire)]
-        self.assert_(len(faces_from_wire) == self.topo.number_of_faces_from_wires(wire))
+        self.assertTrue(len(faces_from_wire) == self.topo.number_of_faces_from_wires(wire))
         wires_from_face = [i for i in self.topo.wires_from_face(face)]
-        self.assert_(len(wires_from_face) == self.topo.number_of_wires_from_face(face))
+        self.assertTrue(len(wires_from_face) == self.topo.number_of_wires_from_face(face))
 
     def test_edges_out_of_scope(self):
         # check pointers going out of scope
-        face = self.topo.faces().next()
+        face = next(self.topo.faces())
         _edges = []
         for edg in Topo(face).edges():
             _edges.append(edg)
@@ -148,7 +148,7 @@ class TestTopo(unittest.TestCase):
 
     def test_wires_out_of_scope(self):
         # check pointers going out of scope
-        wire = self.topo.wires().next()
+        wire = next(self.topo.wires())
         _edges, _vertices = [], []
         for edg in WireExplorer(wire).ordered_edges():
             _edges.append(edg)
@@ -166,7 +166,7 @@ class TestEdge(unittest.TestCase):
         b = get_test_box_shape()
         # take the first edge
         t = Topo(b)
-        edge_0 = t.edges().next()  # it's a TopoDS_Edge
+        edge_0 = next(t.edges())  # it's a TopoDS_Edge
         assert not edge_0.IsNull()
         # then create an edge
         my_edge = Edge(edge_0)
@@ -192,7 +192,7 @@ class TestWire(unittest.TestCase):
         b = get_test_box_shape()
         # take the first edge
         t = Topo(b)
-        wire = t.wires().next()
+        wire = next(t.wires())
         my_wire = Wire(wire)
         assert not my_wire.IsNull()
         assert my_wire.tolerance == 1e-06


### PR DESCRIPTION
This PR fixes a few py3 issues:

* print statements replaced with calls to the print function

* the .next() method for list operators is not supported in py3. Rather use the next() builtin function.
